### PR TITLE
Plucking content from paragraphs, instead of splitting on 'p>'

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -5,13 +5,17 @@ require 'date'
 feed = RSS::Parser.parse("http://feeds.cityofsydney.nsw.gov.au/SydneyDAs", false)
 
 feed.channel.items.each do |item|
-  info_url = item.description.split('<a href="')[1].split('">View')[0]
+  parts = /<p>(.*)<\/p><p>(.*)<\/p><p>(.*)<\/p><p>(.*)<\/p><p>(.*)<\/p>/.match(item.description)
 
+  address, council_ref, description, closing, info_url = parts.captures
+  
+  info_url = /<a href="([^"]+)"/.match(info_url)[1]
   info_url.sub! 'DAsOnExhibition/details.asp?tpk=', 'DASearch/Detail.aspx?id='
 
-  description = item.description.split('p>')[3].gsub('</','')
-
-  exhibition_closes = item.description.split(/Exhibition Closes: \<\/strong\>/i)[1].split('</p>')[0]
+  description = description.gsub(/<\/?strong>/, '')
+  council_ref = /<strong>\s*DA Number:\s*<\/strong>(.+)/i.match(council_ref)[1]
+  exhibition_closes = /<strong>\s*Exhibition Closes:\s*<\/strong>(.+)/i.match(closing)[1]
+  
   on_notice_to = Date.parse(exhibition_closes).strftime('%Y-%m-%d')
 
   record = {
@@ -19,7 +23,7 @@ feed.channel.items.each do |item|
     "description" => description,
     "date_received" => item.pubDate.strftime('%Y-%m-%d'),
     "on_notice_to" => on_notice_to,
-    "council_reference" => item.description.split('DA Number: </strong>')[1].split('<p>')[0],
+    "council_reference" => council_ref,
     "info_url" => info_url,
     "comment_url" => "mailto:dasubmissions@cityofsydney.nsw.gov.au",
     "date_scraped" => Date.today.to_s

--- a/scraper.rb
+++ b/scraper.rb
@@ -1,6 +1,7 @@
 require 'scraperwiki'
 require 'rss/2.0'
 require 'date'
+require 'nokogiri'
 
 feed = RSS::Parser.parse("http://feeds.cityofsydney.nsw.gov.au/SydneyDAs", false)
 
@@ -12,7 +13,7 @@ feed.channel.items.each do |item|
   info_url = /<a href="([^"]+)"/.match(info_url)[1]
   info_url.sub! 'DAsOnExhibition/details.asp?tpk=', 'DASearch/Detail.aspx?id='
 
-  description = description.gsub(/<\/?strong>/, '')
+  description = Nokogiri::HTML.parse(description.gsub(/<\/?strong>/, '')).text
   council_ref = /<strong>\s*DA Number:\s*<\/strong>(.+)/i.match(council_ref)[1]
   exhibition_closes = /<strong>\s*Exhibition Closes:\s*<\/strong>(.+)/i.match(closing)[1]
   


### PR DESCRIPTION
Rejiggered the `item.description` parsing a little.  Aims to fix #3.

I'm not seeing the `<strong>` or `<p>` tags embedded anymore, but shoot it back over if I missed other markup.  
